### PR TITLE
msm_thermal: implement a few improvements

### DIFF
--- a/drivers/thermal/msm_thermal.c
+++ b/drivers/thermal/msm_thermal.c
@@ -22,6 +22,7 @@
 #include <linux/msm_thermal.h>
 #include <linux/platform_device.h>
 #include <linux/of.h>
+#include <linux/ratelimit.h>
 
 unsigned int temp_threshold = 42;
 module_param(temp_threshold, int, 0644);
@@ -55,11 +56,23 @@ enum threshold_levels {
 	LEVEL_HOT		= 2,
 };
 
-struct qpnp_vadc_chip *vadc_dev;
-enum qpnp_vadc_channels adc_chan;
+static struct qpnp_vadc_chip *vadc_dev;
+static enum qpnp_vadc_channels adc_chan;
 
 static struct delayed_work check_temp_work;
 static struct workqueue_struct *thermal_wq;
+
+static void cpu_offline_wrapper(int cpu)
+{
+        if (cpu_online(cpu))
+		cpu_down(cpu);
+}
+
+static void __ref cpu_online_wrapper(int cpu)
+{
+        if (!cpu_online(cpu))
+		cpu_up(cpu);
+}
 
 static int msm_thermal_cpufreq_callback(struct notifier_block *nfb,
 		unsigned long event, void *data)
@@ -89,13 +102,29 @@ static void limit_cpu_freqs(uint32_t max_freq)
 	info.limited_max_freq = max_freq;
 	info.pending_change = true;
 
-	get_online_cpus();
-	for_each_online_cpu(cpu) {
-		cpufreq_update_policy(cpu);
-		pr_info("%s: Setting cpu%d max frequency to %d\n",
-				KBUILD_MODNAME, cpu, info.limited_max_freq);
+	pr_info_ratelimited("%s: Setting cpu max frequency to %u\n",
+		KBUILD_MODNAME, max_freq);
+
+	if (num_online_cpus() < NR_CPUS) {
+		if (max_freq > FREQ_NOTE_7)
+			cpu_online_wrapper(1);
+		if (max_freq > FREQ_HELL)
+			cpu_online_wrapper(2);
+		if (max_freq > FREQ_VERY_HOT)
+			cpu_online_wrapper(3);
 	}
+
+	get_online_cpus();
+	for_each_online_cpu(cpu)
+		cpufreq_update_policy(cpu);
 	put_online_cpus();
+
+	if (max_freq == FREQ_VERY_HOT)
+		cpu_offline_wrapper(3);
+	else if (max_freq == FREQ_HELL)
+		cpu_offline_wrapper(2);
+	else if (max_freq == FREQ_NOTE_7)
+		cpu_offline_wrapper(1);
 
 	info.pending_change = false;
 }
@@ -136,7 +165,8 @@ static void check_temp(struct work_struct *work)
 	}
 
 reschedule:
-	queue_delayed_work(thermal_wq, &check_temp_work, msecs_to_jiffies(250));
+	queue_delayed_work(system_power_efficient_wq,
+                &check_temp_work, msecs_to_jiffies(250));
 }
 
 static int __devinit msm_thermal_dev_probe(struct platform_device *pdev)
@@ -153,11 +183,11 @@ static int __devinit msm_thermal_dev_probe(struct platform_device *pdev)
 	ret = cpufreq_register_notifier(&msm_thermal_cpufreq_notifier,
 		CPUFREQ_POLICY_NOTIFIER);
 	if (ret)
-		pr_err("thermals: well, if this fails here, we're fucked\n");
+		pr_err("thermals: Adam ruins everything\n");
 
 	thermal_wq = alloc_workqueue("thermal_wq", WQ_HIGHPRI, 0);
 	if (!thermal_wq) {
-		pr_err("thermals: don't worry, if this fails we're also bananas\n");
+		pr_err("thermals: don't worry, if this fails we're also fucked\n");
 		goto err;
 	}
 
@@ -202,5 +232,5 @@ static void __exit msm_thermal_device_exit(void)
 	platform_driver_unregister(&msm_thermal_device_driver);
 }
 
-late_initcall(msm_thermal_device_init);
+arch_initcall(msm_thermal_device_init);
 module_exit(msm_thermal_device_exit);


### PR DESCRIPTION
So recently, before finalizing the driver, Franco had been working on a few changes that he abandoned to improve it. I took what was useful from those changes and added them here. I should mention though, that a bit of the work is my own and not Franco's.

1. Cores 1-3 will start shutting off whenever the third threshold is met after the 5th and 4th. This really helps keep the device cool in intense situations, and it does not seem to cause any lag in the userspace. I have tested this with numerous benchmarks and games over the last few hours and it works flawlessly.
2. When checking the temperature, we call a basic worqueue struct named thermal_wq. It acts as a basic worqueue until later when it is assigned with a high priority... It is TOTALLY safe to use a power effecient worqueue here as the initial purpose of the thermal_wq is still served
3. We now use an arch initcall... This is a thermal driver so init related stuff should be brought up earlier
4. pr_info is now ratelimited to avoid spam
5. Just did a general cleanup too...

That's all. Working amazingly well for me, and I am quite happy with this solution now. I may make further adjustments in the future, but for now, this is great